### PR TITLE
additional attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension MojoX-Dispatcher-Qooxdoo-Jsonrpc:
 
+        If the service has a 'controller' property, it will get the current
+        controller context assigned. This supersedes the 'mojo_*'
+        properties, they are now deprecated.
+
 0.80	*** INCOMPATIBLE CHANGES ***
         The QooxdooJsonrpc plugin does not install a /source
         path automatically anymore ... there were too many problem


### PR DESCRIPTION
I have added the ability to hand over a pointer to the controller to the rcp service object instead of handling sessions and stash individually (they are now marked as deprecated). This is more mojo like then before ... 
