### PR TITLE
replace root with paths method as it is deprecated in Mojolicious

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl extension MojoX-Dispatcher-Qooxdoo-Jsonrpc:
 
+        make compatible with Mojolicious::Static API changes
         removed excess loggin left in from development
 
 0.82    make the code more mojoy

--- a/lib/Mojolicious/Plugin/QooxdooJsonrpc.pm
+++ b/lib/Mojolicious/Plugin/QooxdooJsonrpc.pm
@@ -55,7 +55,13 @@ sub register {
                 $app->log->info("Auto register static path mapping from '$prefix' to '$path'");
                 $prefixCache{$prefix} = $path;
             } 
-            $static->root($prefixCache{$prefix});
+            # support the new paths construct
+            if ($static->can('paths')){
+                $static->paths([$prefixCache{$prefix}]);
+            }
+            else {
+                $static->root($prefixCache{$prefix});
+            }
             unless ($static->dispatch($self)){
                 $self->render_text($self->req->url->path.' not found', status => 404);
             }


### PR DESCRIPTION
please push a new CPAN release to get back in sync with Mojolicious changes
