### PR TITLE
fix QX_SRC_MODE

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 Revision history for Perl extension MojoX-Dispatcher-Qooxdoo-Jsonrpc:
+  
+0.87    make sure we do not ship from 'public' in QX_SRC_MODE
 
 0.86    use warn instead of warnings -> fix for rt#75866
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,7 @@ my %WriteMakefileArgs = (
   'PREREQ_PM' => {
     'Mojolicious' => '2.49'
   },
-  'VERSION' => '0.86',
+  'VERSION' => '0.87',
   'test' => {
     'TESTS' => 't/*.t'
   }

--- a/lib/MojoX/Dispatcher/Qooxdoo/Jsonrpc.pm
+++ b/lib/MojoX/Dispatcher/Qooxdoo/Jsonrpc.pm
@@ -9,7 +9,7 @@ use Encode;
 
 our $toUTF8 = find_encoding('utf8');
 
-our $VERSION = '0.86';
+our $VERSION = '0.87';
 
 has 'JSON' => sub { Mojo::JSON->new };
 

--- a/lib/Mojolicious/Plugin/QooxdooJsonrpc.pm
+++ b/lib/Mojolicious/Plugin/QooxdooJsonrpc.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 use File::Spec::Functions qw(splitdir updir catdir file_name_is_absolute);
 use Cwd qw(abs_path);
 
-our $VERSION = '0.86';
+our $VERSION = '0.87';
 # the dispatcher module gets autoloaded, we list it here to
 # make sure it is available and compiles at startup time and not
 # only on demand.
@@ -35,7 +35,8 @@ sub register {
             : $app->home->rel_dir($ENV{QX_SRC_PATH} || catdir(updir,'frontend','source'))
         );
         $app->log->info("Runnning in QX_SRC_MODE with files from $qx_app_src");
-
+        # do NOT ship from public in dev mode
+        $app->static->paths([]);
         my %prefixCache;
         my $static = Mojolicious::Static->new();
         my $static_cb = sub {


### PR DESCRIPTION
This patch makes sure that no files from public get shipped in dev mode as they would be handled BEFORE the source module files have a chance to show up ... 

if any files from public have to be shipped in QX_SRC_MODE the patch would have to be enhanced for this ... 
